### PR TITLE
Fixed an issue where connections weren't being closed

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -93,6 +93,7 @@ class ImpalaConnection(object):
         """
         Close all open Impyla sessions
         """
+        self.reset_connection_pool()
 
     def reset_connection_pool(self):
         if self._connections is not None:


### PR DESCRIPTION
In a previous pull request I fixed a connection leak. In this pull request, though, the close function for the client got truncated. This undoes the truncation.
