### PR TITLE
There are two messages that can happen

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -205,7 +205,14 @@ class ImpalaCursor(object):
             self._cursor.close()
         except HS2Error as e:
             # connection was closed elsewhere
-            if 'invalid query handle' not in e.args[0].lower():
+            already_closed_messages = [
+                'invalid query handle',
+                'invalid session',
+            ]
+            for message in already_closed_messages:
+                if message in e.args[0].lower():
+                    break
+            else:
                 raise
 
     def __enter__(self):


### PR DESCRIPTION
There is another del message I missed

```
Exception impala.error.HiveServer2Error: HiveServer2Error('Invalid session ID',) in <bound method ImpalaCursor.__del__ of <ibis.impala.client.ImpalaCursor object at 0x7f25c3d8bf90>> ignored
```
