### PR TITLE
Setting options

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -149,9 +149,11 @@ class ImpalaConnection(object):
     def _get_cursor(self):
         try:
             cur = self.connection_pool.get(False)
-            if (cur.database != self.database or
-                    cur.options != self.options):
+            if cur.database != self.database:
+                cur.con.close()
                 cur = self._new_cursor()
+            if cur.options != self.options):
+                cur.set_options(options)
             cur.released = False
 
             return cur

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -152,8 +152,9 @@ class ImpalaConnection(object):
             if cur.database != self.database:
                 cur.con.close()
                 cur = self._new_cursor()
-            if cur.options != self.options):
-                cur.set_options(options)
+            if cur.options != self.options:
+                cur.options = options
+                cur.set_options()
             cur.released = False
 
             return cur


### PR DESCRIPTION
There was a connection leak when setting options. Every time you set options, a connection would be taken from the connection pool, a new one would be created and the old one would be lost. This makes it so we simply change the options of a connection in the connection pool rather than dropping it and making a new one with the options we want.