### PR TITLE
Don't set database and don't ensure database

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -164,7 +164,10 @@ class ImpalaConnection(object):
 
     def _new_cursor(self):
         params = self.params.copy()
-        con = impyla.connect(database=self.database, **params)
+        database = None
+        if self.database != 'default':
+            database = self.database
+        con = impyla.connect(database=database, **params)
 
         self._connections[id(con)] = con
 

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -488,7 +488,7 @@ class ImpalaClient(SQLClient):
 
         self._temp_objects = weakref.WeakValueDictionary()
 
-        self._ensure_temp_db_exists()
+        self._ensured = False
 
     def _build_ast(self, expr):
         return build_ast(expr)
@@ -1019,6 +1019,7 @@ class ImpalaClient(SQLClient):
         return self._wrap_new_table(name, database, persist)
 
     def _get_concrete_table_path(self, name, database, persist=False):
+        self._ensure_temp_db_exists()
         if not persist:
             if name is None:
                 name = '__ibis_tmp_{0}'.format(util.guid())
@@ -1034,6 +1035,8 @@ class ImpalaClient(SQLClient):
 
     def _ensure_temp_db_exists(self):
         # TODO: session memoize to avoid unnecessary `SHOW DATABASES` calls
+        if self._ensured:
+            return
         name, path = options.impala.temp_db, options.impala.temp_hdfs_path
         if not self.exists_database(name):
             if self._hdfs is None:
@@ -1041,6 +1044,7 @@ class ImpalaClient(SQLClient):
                       ' may be disabled')
             else:
                 self.create_database(name, path=path, force=True)
+        self._ensured = True
 
     def _wrap_new_table(self, name, database, persist):
         qualified_name = self._fully_qualified_name(name, database)


### PR DESCRIPTION
Impala is falling over on merit-pr. This is my attempt to reduce the load on impala.

When an ibis connection was made, it would do two things. First, switch the database to default. Second, check to make sure a temp database exists. The first is unnecessary because you're on the default database by default so there is no need to switch. The second is unnecessary because we never were using the temp database, so I moved the check to when we would actually use it.