### PR TITLE
PB-266 Master CTAS with partition

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -855,13 +855,6 @@ class ImpalaClient(SQLClient):
             ast = self._build_ast(to_insert)
             select = ast.queries[0]
 
-            if partition is not None:
-                # Fairly certain this is currently the case
-                raise ValueError('partition not supported with '
-                                 'create-table-as-select. Create an '
-                                 'empty partitioned table instead '
-                                 'and insert into those partitions.')
-
             statement = ddl.CTAS(table_name, select,
                                  database=database,
                                  can_exist=force,

--- a/ibis/impala/ddl.py
+++ b/ibis/impala/ddl.py
@@ -142,6 +142,13 @@ class CreateTable(CreateDDL):
         }
         return storage_lines[self.format]
 
+    def _partition(self):
+        if self.partition:
+            return "\nPARTITIONED BY ({})".format(", ".join(self.partition))
+        else:
+            return ''
+
+
 
 class CTAS(CreateTable):
 
@@ -160,6 +167,7 @@ class CTAS(CreateTable):
     def compile(self):
         buf = StringIO()
         buf.write(self._create_line())
+        buf.write(self._partition())
         buf.write(self._storage())
         buf.write(self._location())
 

--- a/ibis/impala/tests/test_ddl.py
+++ b/ibis/impala/tests/test_ddl.py
@@ -291,6 +291,22 @@ SELECT *
 FROM test1""".format(path)
         assert result == expected
 
+    def test_create_table_as_with_partitions(self):
+        partition = ('year', 'month', 'day')
+        select = build_ast(self.con.table('test1')).queries[0]
+        statement = ddl.CTAS('db.test_table',
+                             select,
+                             partition=partition)
+        result = statement.compile()
+
+        expected = """\
+                CREATE TABLE db.test_table
+        PARTIONED BY (year, month, day) AS SELECT *
+        FROM test1"""
+        assert result == expected
+
+
+
     def test_create_table_with_location(self):
         path = '/path/to/table'
         schema = ibis.schema([('foo', 'string'),


### PR DESCRIPTION
For some impala tests we needed to be able to insert tables with partitions, however, that was not supported from whichever ibis version we forked from because Impala/Hive maybe didn't support it back in 2015 when that code was written.
As it turns out, however, that lack of support is no longer an issue. Disabled that Error and added the partition insertion sql statement to include partitions when CTASing with ibis.
This is for PB-266 fi_tests, btw