### PR TITLE
BUG: kudu.connect API usage is incorrect in kudu_support.py

### DIFF
--- a/ibis/impala/kudu_support.py
+++ b/ibis/impala/kudu_support.py
@@ -55,7 +55,8 @@ class KuduImpalaInterface(object):
     def table_exists(self, name):
         return self.client.table_exists(name)
 
-    def connect(self, host_or_hosts, port_or_ports=7051, rpc_timeout=None):
+    def connect(self, host_or_hosts, port_or_ports=7051,
+                rpc_timeout=None, admin_timeout=None):
         """
         Pass-through connection interface to the Kudu client
 
@@ -67,13 +68,16 @@ class KuduImpalaInterface(object):
           If you pass multiple host names, pass multiple ports
         rpc_timeout : kudu.TimeDelta
           See Kudu client documentation for details
+        admin_timeout : kudu.TimeDelta
+          See Kudu client documentation for details
 
         Returns
         -------
         None
         """
         self.client = kudu.connect(host_or_hosts, port_or_ports,
-                                   rpc_timeout=rpc_timeout)
+                                   rpc_timeout_ms=rpc_timeout,
+                                   admin_timeout_ms=admin_timeout)
 
     def _check_connected(self):
         if not self.is_connected:


### PR DESCRIPTION
Looks like a former Deepfield intern during the time he was an intern for us made a fix to ibis mainline, but didn't apply it to our fork:

- https://github.com/ibis-project/ibis/pull/1053
- https://github.com/ibis-project/ibis/issues/1052
- https://github.com/ibis-project/ibis/commit/225ec59f62fd85c387185a5d2067e2a4d763b28b

This PR cherry-picks that commit. After merging, I'll create a new tag and PR to systems to bump a version and investigate/ask if there are any further steps that I need to take.

Here's the output of a test failure I get when trying to support kudu in our testing infrastructure:

```
============================================================================== FAILURES ===============================================================================
________________________________________________ TestKuduBackedImpalaView.test_single_kudu_backed_table_added_to_view _________________________________________________

self = <fi_tests.impala_core.test_impala_view.TestKuduBackedImpalaView testMethod=test_single_kudu_backed_table_added_to_view>

    def test_single_kudu_backed_table_added_to_view(self):
>       self.env.impala_con.kudu.connect('dfimpala', 7051)

fi_tests/impala_core/test_impala_view.py:164:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ibis.impala.kudu_support.KuduImpalaInterface object at 0x7fe6e95f3650>, host_or_hosts = 'dfimpala', port_or_ports = 7051, rpc_timeout = None

    def connect(self, host_or_hosts, port_or_ports=7051, rpc_timeout=None):
        """
            Pass-through connection interface to the Kudu client
    
            Parameters
            ----------
            host_or_hosts : string or list of strings
              If you have multiple Kudu masters for HA, pass a list
            port_or_ports : int or list of int, default 7051
              If you pass multiple host names, pass multiple ports
            rpc_timeout : kudu.TimeDelta
              See Kudu client documentation for details
    
            Returns
            -------
            None
            """
        self.client = kudu.connect(host_or_hosts, port_or_ports,
>                                  rpc_timeout=rpc_timeout)
E       TypeError: connect() got an unexpected keyword argument 'rpc_timeout'

/pipedream/local/venv/deepfield-env/lib/python2.7/site-packages/ibis/impala/kudu_support.py:76: TypeError
================================================ 3 tests deselected by '-ktest_single_kudu_backed_table_added_to_view' ================================================
====================================================== 1 failed, 3 deselected, 1 pytest-warnings in 2.47 seconds ======================================================
```

And you can see the `rpc_timeout` argument should be `rcp_timeout_ms`:
```
In [1]: import kudu

In [2]: kudu.__version__
Out[2]: '1.7.0'

In [3]: kudu.connect??
Signature: kudu.connect(host, port=7051, admin_timeout_ms=None, rpc_timeout_ms=None)
Source:
def connect(host, port=7051, admin_timeout_ms=None, rpc_timeout_ms=None):
    """
    Connect to a Kudu master server

    Parameters
    ----------
    host : string/list
      Server address of master or a list of addresses
    port : int/list, optional, default 7051
      Server port or list of ports. If a list of addresses is provided and
      only a single port, that port will be used for all master addresses.
    admin_timeout_ms : int, optional
      Admin timeout in milliseconds
    rpc_timeout_ms : int, optional
      RPC timeout in milliseconds

    Returns
    -------
    client : kudu.Client
    """
    addresses = []
    if isinstance(host, list):
        if isinstance(port, list):
            if len(host) == len(port):
                for h, p in zip(host, port):
                    addresses.append('{0}:{1}'.format(h, p))
            else:
                raise ValueError("Host and port lists are not of equal length.")
        else:
            for h in host:
                addresses.append('{0}:{1}'.format(h, port))
    else:
        if isinstance(port, list):
            raise ValueError("List of ports provided but only a single host.")
        else:
            addresses.append('{0}:{1}'.format(host, port))

    return Client(addresses, admin_timeout_ms=admin_timeout_ms,
                  rpc_timeout_ms=rpc_timeout_ms)
File:      /pipedream/local/venv/deepfield-env/lib/python2.7/site-packages/kudu/__init__.py
Type:      function
```