### PR TITLE
PB-621 Improve error message for impala/hive errors

### DIFF
--- a/ibis/impala/compat.py
+++ b/ibis/impala/compat.py
@@ -14,5 +14,5 @@
 
 from impala.error import Error as ImpylaError  # noqa
 from impala.error import HiveServer2Error as HS2Error  # noqa
-from impala._thrift_api import TGetOperationStatusReq
+from impala._thrift_api import TGetOperationStatusReq, TOperationState
 import impala.dbapi as impyla  # noqa

--- a/ibis/impala/compat.py
+++ b/ibis/impala/compat.py
@@ -14,4 +14,5 @@
 
 from impala.error import Error as ImpylaError  # noqa
 from impala.error import HiveServer2Error as HS2Error  # noqa
+from impala._thrift_api import TGetOperationStatusReq
 import impala.dbapi as impyla  # noqa


### PR DESCRIPTION
Currently, whenever ibis fires off a query and something within impala (or hive) breaks, we get the useful error:
`OperationalError: Query 3147c91390914242:fed3fb200000000: 1% Complete (3 out of 256)`.  Telling us that something in impala broke while it was 1% of the way done with whatever we asked it to do. No information on the actual error, however! 
This change is to allow us to peak into impyla and get the actual error message being generated. Now we can return a more useful error message like:
`HiveServer2Error: Query c4cc4b999a32515:ea1e6bc300000000 expired due to execution time limit of 2s000ms`
which exceptionCatcher is looking for and can then convert into a QueryExpiredError. 

Unfortunately, impyla doesn't expose the error message ever or the OperationStatusReq in this version, so we have to get it at the ibis level. 

After this is merged I'll do the systems branch tag/conda part